### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [Documentation](http://classyfile.readthedocs.org/en/latest/) for more i
 ```json
 {
     "require": {
-        "onema/classyfile": "^0.3.0@dev"
+        "onema/classyfile": "^0.5.0@dev"
     },
     "minimum-stability": "dev"
 }

--- a/classyfile
+++ b/classyfile
@@ -16,7 +16,7 @@ $title = '  _____ __    ___    ____ ______  __ ____ ____ __    ____
 \___//____//_/ |_|/___//___/   /_//_/  /___//____//___/  ';
 
 
-$application = new Symfony\Component\Console\Application($title, '0.3.0');
+$application = new Symfony\Component\Console\Application($title, '0.5.0');
 $application->addCommands([
     new \Onema\ClassyFile\Command\GenerateClassesFromFileCommand(),
 ]);

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This library uses the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) to
 ```json
 {
     "require": {
-        "onema/classyfile": "^0.3.0@dev"
+        "onema/classyfile": "^0.5.0@dev"
     },
     "minimum-stability": "dev"
 }

--- a/src/Plugin/GenerateClassFile.php
+++ b/src/Plugin/GenerateClassFile.php
@@ -57,6 +57,6 @@ class GenerateClassFile implements EventSubscriberInterface
         }
 
         $location = sprintf('%s/%s.php', $fileLocation, $name);
-        $this->filesystem->write($location, $code);
+        $this->filesystem->put($location, $code);
     }
 }

--- a/tests/ClassyFileTest.php
+++ b/tests/ClassyFileTest.php
@@ -46,20 +46,35 @@ class ClassyFileTest extends \PHPUnit_Framework_TestCase
     {
         $mockAdapter = $this->getMockBuilder('\League\Flysystem\Adapter\Local')
             ->disableOriginalConstructor()
-            ->setMethods(['has', 'createDir', 'write'])
+            ->setMethods(['has', 'createDir', 'update', 'write'])
             ->getMock();
 
-        // plugin calls this method 3 times, internally write calls this method each time checking if
-        // the file exist. write has must always return false otherwise it will throw an exception.
-        $mockAdapter->expects($this->exactly(6))
+        // plugin calls this method 3 times, internally put calls this method each time checking if
+        // the file exist.
+
+        $mockAdapter->expects($this->exactly(9))
             ->method('has')
-            ->will($this->onConsecutiveCalls(false, false, true, false, true, false));
+            ->will($this->onConsecutiveCalls(
+                false, // create dir
+                false, // put file -> write
+                false, // write file
+                true, // create dir
+                true, // put file -> update
+                true, // update file
+                true, // create dir
+                true, // put file -> update
+                true // update file
+            ));
 
         $mockAdapter->expects($this->once())
             ->method('createDir')
             ->willReturn(true);
 
-        $mockAdapter->expects($this->exactly(3))
+        $mockAdapter->expects($this->exactly(2))
+            ->method('update')
+            ->willReturn(true);
+
+        $mockAdapter->expects($this->once())
             ->method('write')
             ->willReturn(true);
 

--- a/tests/GenerateClassFileTest.php
+++ b/tests/GenerateClassFileTest.php
@@ -31,15 +31,15 @@ class GenerateClassFileTest extends \PHPUnit_Framework_TestCase
 
         // plugin calls this method 3 times, internally write calls this method each time checking if
         // the file exist. write has must always return false otherwise it will throw an exception.
-        $mockAdapter->expects($this->exactly(2))
+        $mockAdapter->expects($this->exactly(3))
             ->method('has')
-            ->will($this->onConsecutiveCalls(false, false));
+            ->will($this->onConsecutiveCalls(false, false, false));
 
         $mockAdapter->expects($this->once())
             ->method('createDir')
             ->willReturn(true);
 
-        $mockAdapter->expects($this->exactly(1))
+        $mockAdapter->expects($this->once())
             ->method('write')
             ->willReturn(true);
 


### PR DESCRIPTION
- Generate class file uses the method `put` instead of `write`. This will overwrite existing files. 
